### PR TITLE
feat: Implement light/dark theme switcher

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,15 +5,14 @@
 @tailwind utilities;
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #ffffff; /* White */
+  --foreground: #171717; /* Near black */
 }
 
-@media (prefers-color-scheme: feSpotLight) {
-  :root {
-    --background: #ffffff;
-    --foreground: #ededed;
-  }
+/* Define dark mode variables when .dark class is present on html */
+html.dark {
+  --background: #18181b; /* A dark zinc/gray color */
+  --foreground: #f8f8f8; /* A light gray/off-white color */
 }
 
 body {

--- a/src/components/sections/Header.tsx
+++ b/src/components/sections/Header.tsx
@@ -1,34 +1,60 @@
 import Link from 'next/link'
 import { ProfileDropdown } from '../ProfileDropdown'
 import { FaGithub } from 'react-icons/fa'
+import { useTheme } from 'next-themes'
+import { Sun, Moon } from 'lucide-react'
+import { Button } from '@/components/ui/button' // Assuming Button component is available
+import { useState, useEffect } from 'react'
 
 export function Header() {
+  const { setTheme, resolvedTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => setMounted(true), [])
+
   return (
-    <header className="fixed top-0 left-0 right-0 bg-white border-b border-gray-800 z-50">
+    <header className="fixed top-0 left-0 right-0 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800 z-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           {/* Left side: Logo */}
           <div className="flex items-center">
             <Link href="/" className="flex items-center">
-              <span className="text-xl font-bold text-gray-900">
+              <span className="text-xl font-bold text-gray-900 dark:text-gray-100">
                 Git<span className="text-[#F6A55f]">Rag</span>
               </span>
             </Link>
           </div>
 
-          {/* Right side: GitHub + Profile */}
+          {/* Right side: GitHub + Theme Toggle + Profile */}
           <div className="flex items-center gap-4 ml-auto">
-            <Link 
-              href="https://github.com/shrideep-tamboli/GitRAG" 
+            <Link
+              href="https://github.com/shrideep-tamboli/GitRAG"
               target="_blank"
-              className="text-gray-600 hover:text-gray-900"
+              className="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
             >
               <FaGithub className="w-6 h-6" />
             </Link>
 
-            {/* Spacer to push profile image far right */}
-            <div className="flex-1" />
-
+            {/* Theme Toggle Button */}
+            {mounted ? (
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label="Toggle theme"
+                className="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+                onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
+              >
+                {resolvedTheme === 'dark' ? (
+                  <Sun className="w-5 h-5" />
+                ) : (
+                  <Moon className="w-5 h-5" />
+                )}
+              </Button>
+            ) : (
+              <div className="w-9 h-9" /> // Placeholder for the button to prevent layout shift
+            )}
+            
+            {/* Spacer to push profile image far right - REMOVED as gap-4 on parent should handle spacing */}
             {/* Profile aligned to far right */}
             <ProfileDropdown />
           </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
 
 export default {
+  darkMode: 'class',
   content: [
     "./src/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",


### PR DESCRIPTION
Adds a theme switcher button to the header with sun/moon icons to toggle between light and dark modes.

Key changes:
- Configured `tailwind.config.ts` with `darkMode: 'class'`.
- Used `next-themes` library for theme management; `ThemeProvider` was already partially set up.
- Added a theme toggle button to `Header.tsx` using `useTheme` hook and Lucide icons (Sun/Moon).
- Implemented logic to handle SSR hydration for the theme button.
- Updated `globals.css` to define `--background` and `--foreground` CSS variables for both light and dark themes, ensuring base styles adapt.
- Added initial dark mode styling to the `Header` component itself.

The theme preference should be persisted via local storage by `next-themes`.